### PR TITLE
[WO-326] correctly parse input addresses

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -3,13 +3,13 @@
 require.config({
     baseUrl: '../',
     paths: {
-        'test': '../test',
-        'chai': '../node_modules/chai/chai',
-        'addressparser': '../node_modules/addressparser/src/addressparser',
-        'mimetypes': '../node_modules/mimetypes/src/mimetypes',
-        'mimefuncs': '../node_modules/mimefuncs/src/mimefuncs',
-        'punycode': '../node_modules/punycode/punycode.min',
-        'stringencoding': '../node_modules/mimefuncs/node_modules/stringencoding/dist/stringencoding'
+        'test': './test',
+        'chai': './node_modules/chai/chai',
+        'addressparser': './node_modules/addressparser/src/addressparser',
+        'mimetypes': './node_modules/mimetypes/src/mimetypes',
+        'mimefuncs': './node_modules/mimefuncs/src/mimefuncs',
+        'punycode': './node_modules/punycode/punycode.min',
+        'stringencoding': './node_modules/mimefuncs/node_modules/stringencoding/dist/stringencoding'
     }
 });
 

--- a/test/mailbuild-unit.js
+++ b/test/mailbuild-unit.js
@@ -423,6 +423,30 @@ define(['chai', '../src/mailbuild'], function(chai, Mailbuild) {
 
                 expect(/^Content-Type: application\/zip; name=jogeva.zip$/m.test(msg)).to.be.true;
             });
+
+            it('should convert address objects', function() {
+                var msg = new Mailbuild(false).
+                setHeader({
+                    from: [{
+                        name: 'the safewithme testuser',
+                        address: 'safewithme.testuser@jõgeva.com'
+                    }],
+                    cc: [{
+                        name: 'the safewithme testuser',
+                        address: 'safewithme.testuser@jõgeva.com'
+                    }]
+                });
+
+                expect(/^From: "the safewithme testuser" <safewithme.testuser@xn\-\-jgeva-dua.com>$/m.test(msg.build())).to.be.true;
+                expect(/^Cc: "the safewithme testuser" <safewithme.testuser@xn\-\-jgeva-dua.com>$/m.test(msg.build())).to.be.true;
+
+                expect(msg.getEnvelope()).to.deep.equal({
+                    from: 'safewithme.testuser@xn--jgeva-dua.com',
+                    to: [
+                        'safewithme.testuser@xn--jgeva-dua.com'
+                    ]
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
Fixed address parsing. Also fixed paths in the test/index.js (to be able to run the tests in a local browser).

It is safe to use unicode domains when generating addresses, these are parsed to punycide versions automatically.
