### PR TITLE
[WO-341] Ensure there is a length limit for mime encoded strings

### DIFF
--- a/src/mailbuild.js
+++ b/src/mailbuild.js
@@ -360,7 +360,7 @@
         }
 
         if (this.filename) {
-            filename = mimefuncs.mimeWordsEncode(this.filename, 'Q');
+            filename = mimefuncs.mimeWordsEncode(this.filename, 'Q', 52);
             if (!this.getHeader('Content-Disposition')) {
                 this.setHeader('Content-Disposition', 'attachment');
             }
@@ -633,7 +633,7 @@
             default:
                 value = (value || '').toString().replace(/\r?\n|\r/g, ' ');
                 // mimeWordsEncode only encodes if needed, otherwise the original string is returned
-                return mimefuncs.mimeWordsEncode(value, 'Q');
+                return mimefuncs.mimeWordsEncode(value, 'Q', 52);
         }
     };
 
@@ -652,7 +652,7 @@
         [].concat(addresses || []).forEach(function(address) {
             if (address.address) {
                 address.address = address.address.replace(/^.*?(?=\@)/, function(user) {
-                    return mimefuncs.mimeWordsEncode(user, 'Q');
+                    return mimefuncs.mimeWordsEncode(user, 'Q', 52);
                 }).replace(/@.+$/, function(domain) {
                     return '@' + punycode.toASCII(domain.substr(1));
                 });
@@ -660,7 +660,7 @@
                 if (!address.name) {
                     values.push(address.address);
                 } else if (address.name) {
-                    address.name = mimefuncs.mimeWordsEncode(address.name, 'Q');
+                    address.name = mimefuncs.mimeWordsEncode(address.name, 'Q', 52);
                     values.push('"' + address.name + '" <' + address.address + '>');
                 }
 

--- a/test/mailbuild-unit.js
+++ b/test/mailbuild-unit.js
@@ -290,6 +290,15 @@ define(function(require) {
                 expect(/^Subject: =\?UTF-8\?Q\?j=C3=B5geval\?= istus =\?UTF-8\?Q\?k=C3=A4gu\?= metsas$/m.test(msg)).to.be.true;
             });
 
+            it('should have unicode subject with strange characters', function() {
+                var msg = new Mailbuild('text/plain').
+                setHeader({
+                    subject: 'ˆ¸ÁÌÓıÏˇÁÛ^¸\\ÁıˆÌÁÛØ^\\˜Û˝™ˇıÓ¸^\\˜ﬁ^\\·\\˜Ø^£˜#ﬁ^\\£ﬁ^\\£ﬁ^\\'
+                }).build();
+
+                expect(msg.match(/\bSubject: [^\r]*\r\n( [^\r]*\r\n)*/)[0]).to.equal('Subject: =?UTF-8?Q?=CB=86=C2=B8=C3=81=C3=8C=C3=93=C4=B1?=\r\n =?UTF-8?Q?=C3=8F=CB=87=C3=81=C3=9B^=C2=B8\\=C3=81?=\r\n =?UTF-8?Q?=C4=B1=CB=86=C3=8C=C3=81=C3=9B=C3=98^\\?=\r\n =?UTF-8?Q?=CB=9C=C3=9B=CB=9D=E2=84=A2=CB=87=C4=B1?=\r\n =?UTF-8?Q?=C3=93=C2=B8^\\=CB=9C=EF=AC=81^\\=C2=B7\\?=\r\n =?UTF-8?Q?=CB=9C=C3=98^=C2=A3=CB=9C#=EF=AC=81^\\?=\r\n =?UTF-8?Q?=C2=A3=EF=AC=81^\\=C2=A3=EF=AC=81^\\?=\r\n');
+            });
+
             it('should setContent (arraybuffer)', function() {
                 var arr = new Uint8Array(256),
                     msg = new Mailbuild('text/plain').


### PR DESCRIPTION
Currently the limit for mime encoded string lengths was not set, which resulted in overly long lines in certain input. This update fixes this by forcing length limits.
