### PR TITLE
[WO-358] Do no use quotes with mime-word encoded address names

### DIFF
--- a/src/mailbuild.js
+++ b/src/mailbuild.js
@@ -544,7 +544,7 @@
      * @return {String} escaped and quoted (if needed) argument value
      */
     MimeNode.prototype._escapeHeaderArgument = function(value) {
-        if (value.match(/[\s'\\';\/=]|^\-/g)) {
+        if (value.match(/[\s'"\\;\/=]|^\-/g)) {
             return '"' + value.replace(/(["\\])/g, "\\$1") + '"';
         } else {
             return value;
@@ -660,19 +660,35 @@
                 if (!address.name) {
                     values.push(address.address);
                 } else if (address.name) {
-                    address.name = mimefuncs.mimeWordsEncode(address.name, 'Q', 52);
-                    values.push('"' + address.name + '" <' + address.address + '>');
+                    values.push(this._encodeAddressName(address.name) + ' <' + address.address + '>');
                 }
 
                 if (uniqueList.indexOf(address.address) < 0) {
                     uniqueList.push(address.address);
                 }
             } else if (address.group) {
-                values.push(address.name + ':' + (address.group.length ? this._convertAddresses(address.group, uniqueList) : '').trim() + ';');
+                values.push(this._encodeAddressName(address.name) + ':' + (address.group.length ? this._convertAddresses(address.group, uniqueList) : '').trim() + ';');
             }
         }.bind(this));
 
         return values.join(', ');
+    };
+
+    /**
+     * If needed, mime encodes the name part
+     *
+     * @param {String} name Name part of an address
+     * @returns {String} Mime word encoded string if needed
+     */
+    MimeNode.prototype._encodeAddressName = function(name) {
+        if (!/^[\w ']*$/.test(name)) {
+            if (/^[\x20-\x7e]*$/.test(name)) {
+                return '"' + name.replace(/([\\"])/g, '\\$1') + '"';
+            } else {
+                return mimefuncs.mimeWordEncode(name, 'Q', 52);
+            }
+        }
+        return name;
     };
 
     return MimeNode;

--- a/test/mailbuild-unit.js
+++ b/test/mailbuild-unit.js
@@ -423,8 +423,8 @@ define(function(require) {
                     }]
                 });
 
-                expect(/^From: "the safewithme testuser" <safewithme.testuser@xn\-\-jgeva-dua.com>$/m.test(msg.build())).to.be.true;
-                expect(/^Cc: "the safewithme testuser" <safewithme.testuser@xn\-\-jgeva-dua.com>$/m.test(msg.build())).to.be.true;
+                expect(/^From: the safewithme testuser <safewithme.testuser@xn\-\-jgeva-dua.com>$/m.test(msg.build())).to.be.true;
+                expect(/^Cc: the safewithme testuser <safewithme.testuser@xn\-\-jgeva-dua.com>$/m.test(msg.build())).to.be.true;
 
                 expect(msg.getEnvelope()).to.deep.equal({
                     from: 'safewithme.testuser@xn--jgeva-dua.com',
@@ -628,7 +628,7 @@ define(function(require) {
                 expect(mb._encodeHeaderValue('from', {
                     name: 'the safewithme testuser',
                     address: 'safewithme.testuser@jõgeva.com'
-                })).to.equal('"the safewithme testuser" <safewithme.testuser@xn--jgeva-dua.com>');
+                })).to.equal('the safewithme testuser <safewithme.testuser@xn--jgeva-dua.com>');
             });
         });
 
@@ -647,7 +647,39 @@ define(function(require) {
                         address: 'mozart@example.com',
                         name: 'Mozzie'
                     }]
-                }])).to.equal('"=?UTF-8?Q?J=C3=B5geva?= Ants" <ants@xn--jgeva-dua.ee>, Composers:"Bach, Sebastian" <sebu@example.com>, "Mozzie" <mozart@example.com>;');
+                }])).to.equal('=?UTF-8?Q?J=C3=B5geva_Ants?= <ants@xn--jgeva-dua.ee>, Composers:"Bach, Sebastian" <sebu@example.com>, Mozzie <mozart@example.com>;');
+            });
+
+            it('should keep ascii name as is', function() {
+                var mb = new Mailbuild();
+                expect(mb._convertAddresses([{
+                    name: 'O\'Vigala Sass',
+                    address: 'a@b.c'
+                }])).to.equal('O\'Vigala Sass <a@b.c>');
+            });
+
+            it('should include name in quotes for special symbols', function() {
+                var mb = new Mailbuild();
+                expect(mb._convertAddresses([{
+                    name: 'Sass, Vigala',
+                    address: 'a@b.c'
+                }])).to.equal('"Sass, Vigala" <a@b.c>');
+            });
+
+            it('should escape quotes', function() {
+                var mb = new Mailbuild();
+                expect(mb._convertAddresses([{
+                    name: '"Vigala Sass"',
+                    address: 'a@b.c'
+                }])).to.equal('"\\"Vigala Sass\\"" <a@b.c>');
+            });
+
+            it('should mime encode unicode names', function() {
+                var mb = new Mailbuild();
+                expect(mb._convertAddresses([{
+                    name: '"Jõgeva Sass"',
+                    address: 'a@b.c'
+                }])).to.equal('=?UTF-8?Q?=22J=C3=B5geva_Sass=22?= <a@b.c>');
             });
         });
     });


### PR DESCRIPTION
If the name part of an address consists only ascii letters and numbers, the name is kept as is. If the name includes printable punctuation marks, the name is surrounded with quotes. If the name includes non printable or non ascii characters, it is encoded to mime word.
