### PR TITLE
Do not include epmty lines in the message header

### DIFF
--- a/src/mailbuild.js
+++ b/src/mailbuild.js
@@ -399,6 +399,11 @@
                     return;
             }
 
+            // skip empty lines
+            if (!value) {
+                return;
+            }
+
             lines.push(mimefuncs.foldLines(key + ': ' + this._encodeHeaderValue(key, value), 76));
         }.bind(this));
 

--- a/test/mailbuild-unit.js
+++ b/test/mailbuild-unit.js
@@ -433,6 +433,28 @@ define(function(require) {
                     ]
                 });
             });
+
+            it('should skip empty header', function() {
+                var mb = new Mailbuild('text/plain').
+                setHeader({
+                    a: 'b',
+                    cc: '',
+                    date: 'zzz',
+                    'message-id': '67890'
+                }).
+                setContent('Hello world!'),
+
+                expected = 'Content-Type: text/plain\r\n' +
+                    'A: b\r\n' +
+                    'Date: zzz\r\n' +
+                    'Message-Id: <67890>\r\n' +
+                    'Content-Transfer-Encoding: 7bit\r\n' +
+                    'MIME-Version: 1.0\r\n' +
+                    '\r\n' +
+                    'Hello world!';
+
+                expect(mb.build()).to.equal(expected);
+            });
         });
 
         describe('#getEnvelope', function() {


### PR DESCRIPTION
Currently all messages include the Cc header even if there are no Cc recipients. This update removes all empty values from the header.
