### PR TITLE
[WO-402] Generate better Message-Id values

### DIFF
--- a/src/mailbuild.js
+++ b/src/mailbuild.js
@@ -417,7 +417,18 @@
             }
             // You really should define your own Message-Id field
             if (!this.getHeader('Message-Id')) {
-                lines.push('Message-Id: <' + this.date.getTime() + '@localhost>');
+                lines.push('Message-Id: <' +
+                    // crux to generate random strings like this:
+                    // "1401391905590-58aa8c32-d32a065c-c1a2aad2"
+                    [0, 0, 0].reduce(function(prev) {
+                        return prev + '-' + Math.floor((1 + Math.random()) * 0x100000000).
+                        toString(16).
+                        substring(1);
+                    }, Date.now()) +
+                    '@' +
+                    // try to use the domain of the FROM address or fallback localhost
+                    (this.getEnvelope().from || 'localhost').split('@').pop() +
+                    '>');
             }
             if (!this.getHeader('MIME-Version')) {
                 lines.push('MIME-Version: 1.0');

--- a/test/mailbuild-unit.js
+++ b/test/mailbuild-unit.js
@@ -499,6 +499,21 @@ define(function(require) {
 
                 expect(mb.build()).to.equal(expected);
             });
+
+            it('should use from domain for message-id', function() {
+                var mb = new Mailbuild('text/plain').
+                setHeader({
+                    from: 'test@example.com'
+                });
+
+                expect(/^Message-Id: <\d+(\-[a-f0-9]{8}){3}@example\.com>$/m.test(mb.build())).to.be.true;
+            });
+
+            it('should fallback to localhost for message-id', function() {
+                var mb = new Mailbuild('text/plain');
+
+                expect(/^Message-Id: <\d+(\-[a-f0-9]{8}){3}@localhost>$/m.test(mb.build())).to.be.true;
+            });
         });
 
         describe('#getEnvelope', function() {


### PR DESCRIPTION
Instead of &lt;timestamp@localhost&gt; use &lt;timestamp-randhex-randhex-randhex@fromdomain&gt;
