### PR TITLE
[WO-584] Do not use quotes for encoded filenames

### DIFF
--- a/src/mailbuild.js
+++ b/src/mailbuild.js
@@ -545,11 +545,9 @@
             // filename might include unicode characters so it is a special case
             if (param === 'filename') {
                 mimefuncs.continuationEncode(param, structured.params[param], 50).forEach(function(encodedParam) {
-                    if (encodedParam.key === param) {
-                        paramsArray.push(encodedParam.key + '=' + encodedParam.value);
-                    } else {
-                        paramsArray.push(encodedParam.key + '="' + encodedParam.value + '"');
-                    }
+                    // continuation encoded strings are always escaped, so no need to use enclosing quotes
+                    // in fact using quotes might end up with invalid filenames in some clients
+                    paramsArray.push(encodedParam.key + '=' + encodedParam.value);
                 });
             } else {
                 paramsArray.push(param + '=' + this._escapeHeaderArgument(structured.params[param]));

--- a/test/mailbuild-unit.js
+++ b/test/mailbuild-unit.js
@@ -394,7 +394,7 @@
                 expect(/\r\n\r\nj=C3=B5geva$/.test(msg)).to.be.true;
                 expect(/^Content-Type: text\/plain; charset=utf-8$/m.test(msg)).to.be.true;
                 expect(/^Content-Transfer-Encoding: quoted-printable$/m.test(msg)).to.be.true;
-                expect(/^Content-Disposition: attachment; filename\*0\*="utf-8''j%C3%B5geva.txt"$/m.test(msg)).to.be.true;
+                expect(/^Content-Disposition: attachment; filename\*0\*=utf-8''j%C3%B5geva.txt$/m.test(msg)).to.be.true;
             });
 
             it('should detect content type from filename', function() {


### PR DESCRIPTION
Skip quotes for continuation encoded filenames. The filenames are already safely encoded so no need to use quotes anyway. 

If quotes are used gmail parses "äää" to "utf-8''äää",
