### PR TITLE
Adding option to include bcc in header of the rfc2822 message output

### DIFF
--- a/src/builder-unit.js
+++ b/src/builder-unit.js
@@ -247,7 +247,7 @@ describe('Mimebuilder', function () {
       expect(msg).to.equal(expected)
     })
 
-    it('should not inclide bcc missing in output, but in envelope', function () {
+    it('should not include bcc in output, but in envelope', function () {
       const mb = new Mimebuilder('text/plain')
         .setHeader({
           from: 'sender@example.com',
@@ -265,6 +265,26 @@ describe('Mimebuilder', function () {
       expect(/^From: sender@example.com$/m.test(msg)).to.be.true
       expect(/^To: receiver@example.com$/m.test(msg)).to.be.true
       expect(!/^Bcc:/m.test(msg)).to.be.true
+    })
+
+    it('should include bcc in output, and in envelope', function () {
+      const mb = new Mimebuilder('text/plain', {includeBccInHeader: true})
+        .setHeader({
+          from: 'sender@example.com',
+          to: 'receiver@example.com',
+          bcc: 'bcc@example.com'
+        })
+      const msg = mb.build()
+      const envelope = mb.getEnvelope()
+
+      expect(envelope).to.deep.equal({
+        from: 'sender@example.com',
+        to: ['receiver@example.com', 'bcc@example.com']
+      })
+
+      expect(/^From: sender@example.com$/m.test(msg)).to.be.true
+      expect(/^To: receiver@example.com$/m.test(msg)).to.be.true
+      expect(/^Bcc: bcc@example.com$/m.test(msg)).to.be.true
     })
 
     it('should have unicode subject', function () {

--- a/src/builder.js
+++ b/src/builder.js
@@ -86,6 +86,11 @@ export default class MimeNode {
     if (contentType) {
       this.setHeader('content-type', contentType)
     }
+
+    /**
+     * If true then BCC header is included in RFC2822 message.
+     */
+    this.includeBccInHeader = options.includeBccInHeader || false
   }
 
   /**
@@ -353,8 +358,10 @@ export default class MimeNode {
           value = buildHeaderValue(structured)
           break
         case 'Bcc':
-          // skip BCC values
-          return
+          if (this.includeBccInHeader === false) {
+            // skip BCC values
+            return
+          }
       }
 
       // skip empty lines


### PR DESCRIPTION
Thank you so much for the library! IT is really very helpful.

I wanted to add this small change that I'm blocked on, our mail server would like to receive the rfc2822 with BCC field in the header, and they take care of removing the BCC line before sending it to the recipients. 

For this, I'm making a small change to allow callers to provide a flag in the options called "includeBccInHeader", if this is not passed then it is false and maintains the current logic i.e. BCC is not in the output, but if the user passes true for this option, then BCC is included in the rfc2822 message.

I've added the unit test case for this change as well.

Could you kindly check this and merge this pull request?

Thanks