### PR TITLE
Fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install via
 ... and then use via
 
 ```javascript
-import Mimebuilder from 'emailjs-mime-builder'
+import MimeBuilder from 'emailjs-mime-builder'
 ```
 
 Create a new `MimeBuilder` object with


### PR DESCRIPTION
I think it's easier to understand if you import 'MimeBuilder', that is used in the example.